### PR TITLE
Build arm executables instead of x86-64 executables in e.g. scripts/

### DIFF
--- a/.jenkins/build.sh
+++ b/.jenkins/build.sh
@@ -8,15 +8,18 @@ COMMIT_TIMESTAMP="$(git log -1 --pretty=format:%at)"
 
 export ARCH=arm
 
+export CROSS_PREFIX=/host-rootfs/usr/bin/arm-linux-gnueabihf-
+export CROSS_CC=/host-rootfs/usr/bin/arm-linux-gnueabihf-gcc
+
 # configure RPi2 kernel
 rm -rf .build
-make O=.build bcm2709_defconfig
+make O=.build CROSS_COMPILE=$CROSS_PREFIX bcm2709_defconfig
 
 cd .build
 # use timestamp as deb version
 echo $COMMIT_TIMESTAMP > .version
 
-make CC=/host-rootfs/usr/bin/arm-linux-gnueabihf-gcc bindeb-pkg -j16
+make CC=$CROSS_CC bindeb-pkg -j16
 
 # move results
 mkdir -p ../.output
@@ -25,13 +28,13 @@ mv ../*deb ../.output
 # configure RPi kernel
 cd "$SCRIPT_PATH/.."
 rm -rf .build
-make O=.build bcmrpi_defconfig
+make O=.build CROSS_COMPILE=$CROSS_PREFIX bcmrpi_defconfig
 
 cd .build
 # use timestamp as deb version
 echo $COMMIT_TIMESTAMP > .version
 
-make CC=/host-rootfs/usr/bin/arm-linux-gnueabihf-gcc bindeb-pkg -j16
+make CC=$CROSS_CC bindeb-pkg -j16
 mv ../*deb ../.output
 
 # cleanup


### PR DESCRIPTION
Please merge, this should fix https://github.com/machinekit/machinekit/issues/955#issuecomment-222560899 .
